### PR TITLE
fixed signed char overflow (command length > 128 becomes negative err…

### DIFF
--- a/src/ESP32FtpServer.cpp
+++ b/src/ESP32FtpServer.cpp
@@ -762,8 +762,8 @@ void FtpServer::abortTransfer() {
 //     0 if empty line received
 //    length of cmdLine (positive) if no empty line received
 
-int8_t FtpServer::readChar() {
-    int8_t rc = -1;
+int16_t FtpServer::readChar() {
+    int16_t rc = -1;
     if(client.available()) {
         char c = client.read();
         if(c == '\\') {

--- a/src/ESP32FtpServer.h
+++ b/src/ESP32FtpServer.h
@@ -93,7 +93,7 @@ private:
     boolean makePath(char *fullName, char *param);
     uint8_t getDateTime(uint16_t *pyear, uint8_t *pmonth, uint8_t *pday, uint8_t *phour, uint8_t *pminute, uint8_t *second);
     char* makeDateTimeStr(char *tstr, uint16_t date, uint16_t time);
-    int8_t readChar();
+    int16_t readChar();
 
     IPAddress dataIp;              // IP address of client for data
     WiFiClient client;


### PR DESCRIPTION
Hello!
When command + long filename (>127 bytes total) is passed to ftpserver, 
return code (length) becomes negative (error code) 
and then no error message or command processing is executed,
ftp client just hangs untill timeout.
int16_t is minimal fix.
