### PR TITLE
Fix: avoid loss of data at the end of upload

### DIFF
--- a/src/ESP32FtpServer.cpp
+++ b/src/ESP32FtpServer.cpp
@@ -20,6 +20,7 @@
 //  2017: modified by @robo8080
 //  2019: modified by @HenrikSte
 //  2021: modified by @schreibfaul1 add PSRAM and callbacks
+//  2022: modified by @mk279 fix data reception and avoid loss of last bytes
 
 #include "ESP32FtpServer.h"
 
@@ -710,7 +711,7 @@ boolean FtpServer::doRetrieve() {
 }
 //----------------------------------------------------------------------------------------------------------------------
 boolean FtpServer::doStore() {
-    if(data.connected()) {
+    if(data.available()) {
         unsigned long ms0 = millis();
         int32_t nb;
         nb = data.readBytes((uint8_t*) buf, FTP_BUF_SIZE);


### PR DESCRIPTION
Hi Schreibfaul,

I found a bug in the FTPServer code for uploading files. There is still some data available in the stream even if it is not connected anymore. I can provide a testfile for upload test as needed.

I fixed that bug by checking if there is some data available.

Regards,
 mk279